### PR TITLE
feat: 회원가입 유효성 검사 및 중복 확인 기능

### DIFF
--- a/src/pages/Join.jsx
+++ b/src/pages/Join.jsx
@@ -4,10 +4,12 @@ import LinkItem from '@/components/LinkItem';
 import LoginPageContent from '@/components/login/LoginPageContent';
 import Logo from '@/components/Logo';
 import PageHead from '@/components/PageHead';
-import debounce from '@/utils/debounce';
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import Termscheck from '@/components/join/Termscheck';
+import { toast } from 'react-hot-toast';
+import { ClientResponseError } from 'pocketbase';
+import { emailReg, idReg, pwReg } from '@/utils/validation';
 
 export default function Join() {
   const navigate = useNavigate();
@@ -25,33 +27,93 @@ export default function Join() {
   const handleRegister = async (e) => {
     e.preventDefault();
 
-    if (!isAgreed) {
-      alert('약관에 동의해주세요.');
-      return;
-    }
-
-    const { username, nickname, email, password, passwordConfirm } = formState;
-
-    if (password !== passwordConfirm) {
-      alert('비밀번호가 일치하지 않습니다.');
-      return;
-    }
-
-    if (!username || !nickname || !email || !password || !passwordConfirm) {
-      alert('모든 필드를 채워주세요.');
-      return;
-    }
-
     try {
-      await pb.collection('user').create({
-        ...formState,
-        emailVisibility: true,
-      });
+      const { username, nickname, email, password, passwordConfirm } =
+        formState;
 
-      navigate('/login');
+      const newUser = {
+        email: email,
+        emailVisibility: true,
+        username: username,
+        nickname: nickname,
+        password: password,
+        passwordConfirm: passwordConfirm,
+      };
+
+      if (!username) {
+        toast.error('아이디는 필수 입력 값입니다.');
+        return;
+      }
+
+      if (!email) {
+        toast.error('이메일은 필수 입력 값입니다.');
+        return;
+      }
+
+      if (!nickname) {
+        toast.error('닉네임은 필수 입력 값입니다.');
+        return;
+      }
+
+      if (!password) {
+        toast.error('비밀번호는 필수 입력 값입니다.');
+        return;
+      }
+
+      if (!idReg(username)) {
+        toast.error('아이디 형식이 잘못되었습니다.');
+        return;
+      }
+
+      if (!pwReg(password)) {
+        toast.error('비밀번호 형식이 잘못되었습니다.');
+        return;
+      }
+
+      if (!emailReg(email)) {
+        toast.error('이메일 형식이 잘못되었습니다.');
+        return;
+      }
+
+      if (password !== passwordConfirm) {
+        toast.error('비밀번호가 일치하지 않습니다.');
+        return;
+      }
+
+      if (!isAgreed) {
+        toast.error('약관에 동의해주세요.');
+        return;
+      }
+
+      const record = await pb.collection('user').create(newUser);
+
+      if (record?.id) {
+        toast.success('회원가입이 완료됐습니다.');
+        navigate('/login');
+      } else {
+        toast.error('회원가입에 실패했습니다.');
+      }
     } catch (error) {
-      console.error(error);
-      alert('회원 가입에 실패하였습니다.');
+      if (error.response.code === 400) {
+        const { username, email, nickname } = error.response.data;
+
+        if (username && username.message.includes('already')) {
+          toast.error('아이디가 중복됩니다.');
+        }
+
+        if (email && email.message.includes('already')) {
+          toast.error('이메일이 중복됩니다.');
+        }
+
+        if (nickname && nickname.message.includes('unique')) {
+          toast.error('닉네임이 중복됩니다.');
+        }
+      } else {
+        if (!(error instanceof ClientResponseError)) {
+          console.error('회원가입 실패:', error);
+          toast.error('회원가입에 실패했습니다.');
+        }
+      }
     }
   };
 
@@ -62,8 +124,6 @@ export default function Join() {
       [name]: value,
     });
   };
-
-  const handleDebounceInput = debounce(handleInput, 500);
 
   return (
     <>
@@ -80,35 +140,41 @@ export default function Join() {
             type="text"
             name="username"
             placeholder="아이디"
-            onChange={handleDebounceInput}
+            value={formState.username}
+            onChange={handleInput}
           />
           <InputField
             id="password"
             type="password"
             name="password"
             placeholder="비밀번호"
-            onChange={handleDebounceInput}
+            onChange={handleInput}
           />
+          <p className="text-sand">
+            특수문자 포함 최소 8자 이상, 16자 이하로 만들어 주세요.
+          </p>
           <InputField
             id="checkPassword"
             type="password"
             name="passwordConfirm"
             placeholder="비밀번호 확인"
-            onChange={handleDebounceInput}
+            onChange={handleInput}
           />
           <InputField
             id="nickname"
             type="text"
             name="nickname"
             placeholder="닉네임"
-            onChange={handleDebounceInput}
+            value={formState.nickname}
+            onChange={handleInput}
           />
           <InputField
             id="email"
-            type="email"
+            type="text"
             name="email"
             placeholder="이메일"
-            onChange={handleDebounceInput}
+            value={formState.email}
+            onChange={handleInput}
           />
           {/* 약관 동의 */}
           <Termscheck setIsAgreed={setIsAgreed} />

--- a/src/utils/validation.js
+++ b/src/utils/validation.js
@@ -6,6 +6,14 @@ export function idReg(text){
 
 //특수문자포함 최소 8자이상~16자이하 비밀번호정규식
 export function pwReg(text){
-  const reg = /^(?=.*[a-zA-Z])(?=.*[!@#$%^*+=-]).{8,16}$/;
+  const reg = /^(?=.*[a-zA-Z])(?=.*[,~!@#$%^*+=-]).{8,16}$/;
   return reg.test(String(text).toLowerCase());
+}
+
+//이메일 형식 검증 정규식
+export function emailReg(text) {
+  const re =
+    /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
+
+  return re.test(String(text).toLowerCase());
 }


### PR DESCRIPTION
- input 채워지지 않을 시 각각 칸에 맞는 toast.error 띄우기
- 아이디 / 비밀번호 / 이메일 형식 오류 시 toast.error 띄우기
- 아이디 / 이메일 / 닉네임 중복 시 toast.error 띄우기
- 회원가입 실패 시 console과 toast 에러 문구 띄우기
- validation.js 이메일 형식 검증 정규식 추가 
 
related to: #46 